### PR TITLE
Add Open in Kaggle Badge

### DIFF
--- a/LSTM.ipynb
+++ b/LSTM.ipynb
@@ -6,6 +6,9 @@
    "source": [
     "# <a title=\"Activity Recognition\" href=\"https://github.com/guillaume-chevalier/LSTM-Human-Activity-Recognition\" > LSTMs for Human Activity Recognition</a>\n",
     "\n",
+    "<a href=\"https://kaggle.com/kernels/welcome?src=https://github.com/guillaume-chevalier/LSTM-Human-Activity-Recognition/blob/master/LSTM.ipynb\"><img align=\"left\" alt=\"Kaggle\" title=\"Open in Kaggle\" src=\"https://kaggle.com/static/images/open-in-kaggle.svg\"></a>&nbsp;",
+    "<br></br>",
+    "<br></br>",
     "Human Activity Recognition (HAR) using smartphones dataset and an LSTM RNN. Classifying the type of movement amongst six categories:\n",
     "- WALKING,\n",
     "- WALKING_UPSTAIRS,\n",


### PR DESCRIPTION
Add Kaggle Badge that allows for opening the .ipynb as a Kaggle Notebook as seen here https://www.kaggle.com/product-feedback/152480.